### PR TITLE
Fix ExecutionException while executing OpenSiriusJobsGraph

### DIFF
--- a/plugins/fr.cea.nabla.rcp/plugin_customization.ini
+++ b/plugins/fr.cea.nabla.rcp/plugin_customization.ini
@@ -6,5 +6,7 @@ org.eclipse.sirius.diagram/Sirius.Connectors.JumpLink.enableOverride=true
 org.eclipse.sirius.diagram/Sirius.Connectors.JumpLink.status=2
 org.eclipse.sirius.diagram/Sirius.Connectors.JumpLink.type=3
 org.eclipse.sirius.ui/PREF_REFRESH_ON_REPRESENTATION_OPENING=false
+org.eclipse.sirius.ui/PREF_RELOAD_ON_LAST_EDITOR_CLOSE=false
+org.eclipse.sirius.ui/PREF_SAVE_WHEN_NO_EDITOR=false
 org.eclipse.sirius.properties.core/PREF_FILTER_PROPERTIES_VIEW_SEMANTIC_TAB=false
 org.eclipse.sirius.properties.core/PREF_FILTER_PROPERTIES_VIEW_DEFAULT_TAB=false


### PR DESCRIPTION
When a dirty Sirius editor was closed without saving, the 'aird'
InMemory resource was sometimes unloaded.
By setting PREF_RELOAD_ON_LAST_EDITOR_CLOSE & PREF_SAVE_WHEN_NO_EDITOR
preference to false, the sirius policy called when the editor is closed
is longer called. That fixes the ExecutionException.

Change-Id: I29c6eccc21b190e5ec46fe645b525b4aedca15b1
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>