### PR TITLE
[fix] Correct bug on Cardinality

### DIFF
--- a/plugins/fr.cea.nabla/src/fr/cea/nabla/generator/ir/IrExpressionFactory.xtend
+++ b/plugins/fr.cea.nabla/src/fr/cea/nabla/generator/ir/IrExpressionFactory.xtend
@@ -194,6 +194,7 @@ class IrExpressionFactory
 		IrFactory::eINSTANCE.createCardinality =>
 		[ 
 			annotations += e.toNabLabFileAnnotation
+			type = e.typeFor?.toIrType
 			container = e.container.toIrContainer
 			constExpr = constExprServices.isConstExpr(e)
 		]


### PR DESCRIPTION
Type is not fill on creation
-> error Replace unary/binary operators with array arguments by functions

Signed-off-by: OUDOT Marie-Pierre <marie-pierre.oudot@cea.fr>