### PR TITLE
[130] Fix generated src-gen folder location in VSCode extension

### DIFF
--- a/plugins/fr.cea.nabla.vscode.extension/src/extension.ts
+++ b/plugins/fr.cea.nabla.vscode.extension/src/extension.ts
@@ -153,12 +153,11 @@ export function activate(context: ExtensionContext) {
           projectPath.lastIndexOf(projectFolder.name) - 1
         );
         if (wsPath) {
-          const ngenRelativePath = path.relative(wsPath, ngenPath);
           commands.executeCommand(
             "nablabweb.generateCode",
             selectedFileURI.fsPath,
             wsPath,
-            ngenRelativePath
+            projectFolder.name
           );
         }
       }


### PR DESCRIPTION
Bug:https://github.com/cea-hpc/NabLab/issues/130
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>